### PR TITLE
feat: add OpenTelemetry (OTEL) instrumentation support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,7 +26,35 @@ __tunneling_port: 9700
 __mitm_port: 12121
 mitm_use_certificate: False
 
+# OpenTelemetry Configuration
+otel_enabled: false
+otel_version: "2.23.0"
+otel_download_url: "https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v{{ otel_version }}/opentelemetry-javaagent.jar"
+otel_jar_name: "opentelemetry-javaagent.jar"
+otel_jar_full_path: "{{ installation_folder }}/otel/{{ otel_jar_name }}"
+
+otel_service_name: "nvserver"
+otel_environment: "prod"
+otel_namespace: "daict"
+otel_customer: "default"
+otel_alloy_endpoint: "http://{{ otel_alloy_host }}:{{ otel_alloy_port }}"
+otel_alloy_host: "localhost"
+otel_alloy_port: 4317
+
+otel_java_options:
+  - "-javaagent:{{ otel_jar_full_path }}"
+  - "-Dotel.service.name={{ otel_service_name }}"
+  - "-Dotel.resource.attributes=deployment.environment={{ otel_environment }},service.namespace={{ otel_namespace }},customer={{ otel_customer }}"
+  - "-Dotel.exporter.otlp.endpoint={{ otel_alloy_endpoint }}"
+  - "-Dotel.exporter.otlp.protocol=grpc"
+  - "-Dotel.metrics.exporter=otlp"
+  - "-Dotel.logs.exporter=otlp"
+
+# Keep user-provided extra JVM options separate from OTEL options
 extra_java_options: []
+
+# Add OTEL options only when enabled
+enabled_otel_java_options: "{{ otel_java_options if otel_enabled else [] }}"
 
 ## get the interface name from nv server
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,7 +13,7 @@ required_modifiable_fields:
   - mitm_port
 
 # app_name: "nvserver"
-__app_version: 26.4.1016
+__app_version: 26.6.1028
 
 
 # service_name: "{{ app_name }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,7 +13,7 @@ required_modifiable_fields:
   - mitm_port
 
 # app_name: "nvserver"
-__app_version: 26.6.1028
+__app_version: 25.3.915
 
 
 # service_name: "{{ app_name }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,7 +13,7 @@ required_modifiable_fields:
   - mitm_port
 
 # app_name: "nvserver"
-__app_version: 25.3.915
+__app_version: 26.4.1016
 
 
 # service_name: "{{ app_name }}"

--- a/tasks/linux-install.yml
+++ b/tasks/linux-install.yml
@@ -54,3 +54,19 @@
     dest: "{{ temp_folder }}/{{ installer_file_name }}"
     timeout: "{{ download_timeout | default(60) }}"
   when: custom_download_url != ""
+
+- name: Create directory for OTEL jar
+  file:
+    path: "{{ installation_folder }}/otel"
+    state: directory
+    owner: "{{ ansible_user_id }}"
+  become: yes
+  when: otel_enabled | bool
+
+- name: Download OpenTelemetry Java agent jar
+  get_url:
+    url: "{{ otel_download_url }}"
+    dest: "{{ otel_jar_full_path }}"
+    mode: '0644'
+    timeout: "{{ download_timeout | default(60) }}"
+  when: otel_enabled | bool

--- a/tasks/linux-restart.yml
+++ b/tasks/linux-restart.yml
@@ -81,7 +81,7 @@
     path: "{{ installation_folder }}/nvproxyserver.vmoptions"
     line: "{{ item }}"
     regexp: "^{{ item.split('=') | first }}"
-  with_items: "{{ extra_java_options }}"      
+  with_items: "{{ extra_java_options + enabled_otel_java_options }}"
   become: yes
 
 # reset pairing key


### PR DESCRIPTION
## Summary
- Adds full OpenTelemetry signal correlation for traces, logs, and metrics via Grafana Alloy
- Fixes `stage.multiline` placement (moved to first stage) and corrects `firstline` regex to match actual Java log format (`YYYY-MM-DD HH:MM:SS`)
- Extracts only the `body` field from OTEL log JSON so Loki stores the raw log message instead of the full JSON envelope

## Test plan
- [ ] Deploy Alloy via Ansible and verify multiline Java stack traces are combined into single Loki entries
- [ ] Confirm OTEL logs in Loki contain only the log body (not the full JSON blob)
- [ ] Verify traces appear in Tempo with correct service graph metrics